### PR TITLE
Feature/non null assertion android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+- Add null check to getProxySetting DeviceProxyPlugin.kt
+
 ## 0.0.3
 
 - Fix crash on Android 4.3

--- a/android/src/main/kotlin/com/intechlab/device_proxy/DeviceProxyPlugin.kt
+++ b/android/src/main/kotlin/com/intechlab/device_proxy/DeviceProxyPlugin.kt
@@ -47,7 +47,7 @@ class DeviceProxyPlugin(val activity: Activity?) : MethodCallHandler {
         val address = System.getProperty("http.proxyHost")
         val port = System.getProperty("http.proxyPort")
 
-        if(address.isNotEmpty() && port.isNotEmpty()){
+        if(!address.isNullOrEmpty() && !port.isNullOrEmpty()){
           return "$address:$port"
         }
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_proxy
 description: A plugin helps to get device's proxy setting
-version: 0.0.3
+version: 0.0.4
 authors:
   - King Wu <king.wuff101@gmail.com>
 homepage: https://github.com/KingWu/device_proxy


### PR DESCRIPTION
Add a null check to the getProxySetting of DeviceProxyPlugin.kt. This allows the plugin to be used in projects with an Android build gradle version of 4.0.0 and higher.